### PR TITLE
ci: fix e2e tests command

### DIFF
--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
 
             - run: npm ci
 
-            - run: npm run test
+            - run: npm run test:e2e
               env:
                 JWT_SECRET: testing
                 DATABASE_URL: "postgresql://docker:docker@localhost:5432/apisolid?schema=public"


### PR DESCRIPTION
from `npm run test` to `npm run test:e2e`